### PR TITLE
Fix "now playing" update and add graceful closure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 /build/
 /.mypy_cache/
 /.env/
+venv

--- a/aioheos/aioheosgroup.py
+++ b/aioheos/aioheosgroup.py
@@ -13,8 +13,8 @@ class AioHeosGroup(aioheosplayer.AioHeosPlayer):
     def __init__(self, controller, group_json):
         group_json["pid"] = group_json["gid"]
         super().__init__(controller, group_json)
-        _LOGGER.debug("[D] Creating group object %s for controller pid %s",
-                      self._player_id, self._controller._player_id)
+        _LOGGER.debug("[D] Creating group object %s",
+                      self._player_id)
 
     def recreate_group(self):
         " Recreate group "

--- a/aioheos/aioheosplayer.py
+++ b/aioheos/aioheosplayer.py
@@ -9,7 +9,7 @@ import logging
 _LOGGER = logging.getLogger(__name__)
 
 
-class AioHeosPlayer():
+class AioHeosPlayer:
     " Asynchronous Heos Player class "
 
     def __init__(self, controller, player_json):
@@ -32,8 +32,8 @@ class AioHeosPlayer():
         self._media_image_url = None
         self._media_id = None
         self._callback = None
-        _LOGGER.debug("[D] Creating player object %s for controller pid %s",
-                      self._player_id, self._controller._player_id)
+        _LOGGER.debug("[D] Creating player object %s",
+                      self._player_id)
 
     def __lt__(self, other):
         return self._player_id < other.player_id

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-lxml
 aiohttp
+lxml
+pytz

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,9 @@ setup(name='aioheos',
       packages=['aioheos'],
       long_description=open('README.md').read(),
       install_requires=[
-          'lxml',
           'aiohttp',
+          'lxml',
+          'pytz'
       ],
       classifiers=[
         "Programming Language :: Python :: 3",

--- a/test.py
+++ b/test.py
@@ -33,7 +33,7 @@ async def heos_test(loop):
     # do some work...
     await asyncio.sleep(2)
 
-    heos.close()
+    await heos.close()
 
 
 def main():

--- a/test.py
+++ b/test.py
@@ -11,7 +11,7 @@ async def heos_test(loop):
     # host = None
     host = 'HEOS-1'
 
-    heos = aioheos.AioHeosController(loop, host=host, verbose=verbose)
+    heos = aioheos.AioHeosController(loop, host=host)
 
     # connect to player
     await heos.connect()


### PR DESCRIPTION
This PR fixes a few issues:
- Removes `player_id` from the controller class and corrected methods that were still using the hard-coded player_id from device 0.  This resolves the issue where the now playing media was not updating on devices other than the first one.
- Standardized usage of `host` and `post` so that it is used consistently throughout and removed `host` and `post` from `connect` as this was redundant to the parameters passed into `init`.
- Close is now a coroutine and contains logic to ensure a graceful shutdown.
- Added missing package `pytz` to requirements and `setup.py`
